### PR TITLE
Fix uploads static path

### DIFF
--- a/servicios/serviciosgRPC/grcpRecurso/controladores/RecursoGRPC.js
+++ b/servicios/serviciosgRPC/grcpRecurso/controladores/RecursoGRPC.js
@@ -22,7 +22,7 @@ const crearRecurso = async (call, callback) => {
             });
         }
 
-        const uploadsDir = path.resolve(__dirname, '../../../../uploads');
+        const uploadsDir = path.resolve(__dirname, '../../../uploads');
         if (!fs.existsSync(uploadsDir)) {
             fs.mkdirSync(uploadsDir, { recursive: true });
         }

--- a/src/app.js
+++ b/src/app.js
@@ -8,7 +8,7 @@ app.use(express.json());
 app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
 
 app.use('/api/usuarios', require('../servicios/rutasREST/Usuario'));
-app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+app.use('/uploads', express.static(path.join(__dirname, '../servicios/uploads')));
 app.use('/api/recursos', require('../servicios/rutasREST/Recurso'));
 app.use('/api/reacciones', require('../servicios/rutasREST/Reaccion'));
 app.use('/api/comentarios', require('../servicios/rutasREST/Comentario'));
@@ -17,6 +17,5 @@ app.use('/api/comentarios', require('../servicios/rutasREST/Comentario'));
 app.use('/api/publicaciones', require('../servicios/rutasREST/Publicacion'));
 app.use('/api/notificaciones', require('../servicios/rutasREST/Notificacion'));
 app.use('/api/estadisticas', require('../servicios/rutasREST/Estadistica'));
-app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 // app.use('/api/login', require('./rutas/login'));
 module.exports = app;


### PR DESCRIPTION
## Summary
- correct the uploads directory path served by Express
- adjust gRPC file path to save downloads in `servicios/uploads`

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6c5403a0832aa1d1906a8d2a7883